### PR TITLE
Correcting "install_requires" packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
 
     packages=["megamanager"],
 
-    install_requires=['numpy'],
+    install_requires=['numpy', 'psutil'],
     entry_points={
         'console_scripts': [
             'megamanager = megamanager.__main__:main',

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,7 @@ setup(
 
     packages=["megamanager"],
 
-    install_requires=['logging', 'os', 'numpy', 'random', 're', 'shutil',
-                      'signal', 'subprocess', 'tempfile', 'threading', 'time'
-                      ],
+    install_requires=['numpy'],
     entry_points={
         'console_scripts': [
             'megamanager = megamanager.__main__:main',


### PR DESCRIPTION
install_requires is used to install non-standard python packages
'logging', 'os', 'random', 're', 'shutil', 'signal', 'subprocess', 'tempfile', 'threading', 'time'
shouldn't be specified
and "psutil" should be added